### PR TITLE
added create sfr point, line, poly tables

### DIFF
--- a/BIS Tables in GC2.ipynb
+++ b/BIS Tables in GC2.ipynb
@@ -2,11 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -18,11 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -48,11 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": 69,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -78,11 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -107,11 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -141,11 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -181,11 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -219,14 +193,81 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": []
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'success': True, 'affected_rows': 0, '_execution_time': 0.047}\n"
+     ]
+    }
+   ],
+   "source": [
+    "q_createSfrPoly = \"CREATE TABLE IF NOT EXISTS sfr.sfr_poly ( \\\n",
+    "    id serial primary key, \\\n",
+    "    registration jsonb, \\\n",
+    "    alt_info jsonb, \\\n",
+    "    spat_cert varchar(150), \\\n",
+    "    title varchar(250), \\\n",
+    "    ftype varchar(150), \\\n",
+    "    the_geom geometry(MultiPolygon, 3857))\"\n",
+    "url_createSfrPoly = gc2.sqlAPI(\"DataDistillery\",\"BCB\")+\"&q=\"+q_createSfrPoly\n",
+    "print (requests.get(url_createSfrPoly).json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'success': True, 'affected_rows': 0, '_execution_time': 0.04}\n"
+     ]
+    }
+   ],
+   "source": [
+    "q_createSfrLine = \"CREATE TABLE IF NOT EXISTS sfr.sfr_line( \\\n",
+    "    id serial primary key, \\\n",
+    "    registration jsonb, \\\n",
+    "    alt_info jsonb, \\\n",
+    "    spat_cert varchar(150), \\\n",
+    "    title varchar(250), \\\n",
+    "    ftype varchar(150), \\\n",
+    "    the_geom geometry(MultiLineString, 3857))\"\n",
+    "url_createSfrLine = gc2.sqlAPI(\"DataDistillery\",\"BCB\")+\"&q=\"+q_createSfrLine\n",
+    "print (requests.get(url_createSfrLine).json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'success': True, 'affected_rows': 0, '_execution_time': 0.045}\n"
+     ]
+    }
+   ],
+   "source": [
+    "q_createSfrPoint = \"CREATE TABLE IF NOT EXISTS sfr.sfr_point( \\\n",
+    "    id serial primary key, \\\n",
+    "    registration jsonb, \\\n",
+    "    alt_info jsonb, \\\n",
+    "    spat_cert varchar(150), \\\n",
+    "    title varchar(250), \\\n",
+    "    ftype varchar(150), \\\n",
+    "    the_geom geometry(MultiPoint, 3857))\"\n",
+    "url_createSfrPoint = gc2.sqlAPI(\"DataDistillery\",\"BCB\")+\"&q=\"+q_createSfrPoint\n",
+    "print (requests.get(url_createSfrPoint).json())"
+   ]
   }
  ],
  "metadata": {
@@ -245,9 +286,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Added cells to notebook to create sfr_point, sfr_line, and sfr_poly tables.  These are intended to be the three main geospatial layers within the spatial features registry.